### PR TITLE
Don't return packages when we don't know how they are named in Fedora

### DIFF
--- a/hotness_schema/messages.py
+++ b/hotness_schema/messages.py
@@ -99,17 +99,8 @@ class UpdateDrop(message.Message):
             list(str): A list of affected package names or empty list.
         """
         if self.reason == "anitya":
-            # Return name of the project instead of list of Fedora packages
-            # if we don't know how the package is called in Fedora land
-            original = self.body["trigger"]["msg"]
-            project_name = ""
-            if "project" in original:
-                project_name = original["project"]["name"]
-
-            if "message" in original and "project" in original["message"]:
-                project_name = original["message"]["project"]["name"]
-
-            return [project_name]
+            # We don't know how the package is called in Fedora land
+            return []
 
         if "package_listing" in self.body["trigger"]["msg"]:
             original = self.body["trigger"]["msg"]

--- a/hotness_schema/tests/test_messages.py
+++ b/hotness_schema/tests/test_messages.py
@@ -16,10 +16,11 @@
 """Unit tests for the message classes."""
 
 import unittest
+
 import mock
 import pytest
 
-from hotness_schema import UpdateDrop, UpdateBugFile
+from hotness_schema import UpdateBugFile, UpdateDrop
 
 
 class TestUpdateDrop(unittest.TestCase):
@@ -129,38 +130,12 @@ class TestUpdateDrop(unittest.TestCase):
     )
     def test_package_reason_anitya(self, mock_reason):
         """
-        Assert correct package is returned, when reason is anitya.
+        Assert no package is returned, when reason is anitya.
         """
         mock_reason.return_value = "anitya"
         message_body = {"trigger": {"msg": {"project": {"name": "Dummy"}}}}
         with mock.patch.dict(self.message.body, message_body):
-            self.assertEqual(self.message.packages, ["Dummy"])
-
-    @mock.patch(
-        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
-    )
-    def test_package_reason_anitya_no_project(self, mock_reason):
-        """
-        Assert empty list is returned, when reason is anitya and there is no project
-        in message.
-        """
-        mock_reason.return_value = "anitya"
-        message_body = {"trigger": {"msg": {}}}
-        with mock.patch.dict(self.message.body, message_body):
-            self.assertEqual(self.message.packages, [""])
-
-    @mock.patch(
-        "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock
-    )
-    def test_package_reason_anitya_message(self, mock_reason):
-        """
-        Assert correct package is returned, when reason is anitya and body contains
-        message key.
-        """
-        mock_reason.return_value = "anitya"
-        message_body = {"trigger": {"msg": {"message": {"project": {"name": "Dummy"}}}}}
-        with mock.patch.dict(self.message.body, message_body):
-            self.assertEqual(self.message.packages, ["Dummy"])
+            self.assertEqual(self.message.packages, [])
 
     @mock.patch(
         "hotness_schema.messages.UpdateDrop.reason", new_callable=mock.PropertyMock

--- a/news/59.bug
+++ b/news/59.bug
@@ -1,0 +1,1 @@
+Don't return packages when we don't know how they are named in Fedora


### PR DESCRIPTION
The `packages` property is a list of Fedora packages, not a list of project names. If a project is not mapped to a Fedora package, it should be empty.

Fixes: #59