### PR TITLE
Update minimum python version to 3.8.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ exclude = [
 "hotness.update.bug.file" = "hotness_schema:UpdateBugFile"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.8.10"
 fedora-messaging = "^3.1.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
diff-cover 8.0.0+ has minimum python requirements 3.8.10, let's update it then.